### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/example/Projeto_Calingo/infra/security/SecurityConfigurations.java
+++ b/src/main/java/com/example/Projeto_Calingo/infra/security/SecurityConfigurations.java
@@ -28,7 +28,7 @@ public class SecurityConfigurations {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception{
         return httpSecurity
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/auth/login", "/auth/register"))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/CalingoTeam/Back-End/security/code-scanning/1](https://github.com/CalingoTeam/Back-End/security/code-scanning/1)

To fix the issue, CSRF protection should be enabled by removing the `csrf.disable()` call. If there are specific endpoints that need to bypass CSRF protection (e.g., for APIs accessed programmatically), they can be explicitly excluded using Spring Security's `ignoringAntMatchers` or similar configurations. This ensures that CSRF protection is applied to all other endpoints.

The changes will involve:
1. Removing the `csrf.disable()` call on line 31.
2. Optionally, configuring CSRF protection to ignore specific endpoints if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
